### PR TITLE
Update syntax to support python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ dist = setup(
     packages = [__package_name__]
 )
 
-if dist.command_obj.has_key('install'):
+if 'install' in dist.command_obj:
     destination_path = dist.command_obj['install'].install_lib
     package_path = os.path.join(destination_path, __package_name__)
 


### PR DESCRIPTION
Only one change was required, dict no longer uses `has_key`, instead uses `in`

Built and tested the library in python 3, seems to work fine.

This has technically not been backwards tested on python 2 but should work fine according to documentation.