### PR TITLE
Hold pyobject refcount to make Map[Array](np_array) safe

### DIFF
--- a/tests/eigency_tests/eigency_tests.pyx
+++ b/tests/eigency_tests/eigency_tests.pyx
@@ -173,6 +173,17 @@ def function_type_complex64(np.ndarray array):
 def function_single_col_matrix(np.ndarray array):
     return ndarray(_function_single_col_matrix(Map[ArrayXXd](array)))
 
+# Functions testing that map properly holds a reference to python objects.
+def function_map_holds_reference(np.ndarray array):
+    # Hold a reference to a copy of an array.
+    cdef Map[ArrayXXd] eigency_map = Map[ArrayXXd](array.copy(order="K"))
+
+    # Do some nontrivial operation so that array_copy might be clobbered.
+    array_doubled = 2 * array
+
+    # Use the reference to the copy held by eigency_map.
+    return ndarray(_function_type_double(eigency_map))
+
 
 cdef class FixedMatrixClass:
     cdef _FixedMatrixClass *thisptr;

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -220,6 +220,12 @@ class TestEigency(unittest.TestCase):
         mat_in = np.zeros((1,3), order='F')
         mat_out = eigency_tests.function_single_col_matrix(mat_in)
         assert_array_equal(mat_in, mat_out)
+
+    def test_function_map_holds_reference(self):
+        # Tests error fixed by 4ee448a in pull request #18
+        mat_in = np.array([[1., 2., 3., 4.], [5., 6., 7., 8.]], order='F', dtype=np.float64)
+        mat_out = eigency_tests.function_map_holds_reference(mat_in)
+        assert_array_equal(mat_in, mat_out)
         
 if __name__ == '__main__':
     unittest.main(buffer=False)


### PR DESCRIPTION
Before this patch, simple usage of eigency would cause use-after-free in many cases. Consider

    def cython_function(np.ndarray x):
      cdef np.ndarray y = x + 1
      cpp_function(Map[VectorXd](y))

cython may emit code in which the PyObject `y` has its refcount decremented to zero prior to the call to `cpp_function`. In that cases, `cpp_function` will read the already-freed contents of memory owned by `y`. This patch causes eigency::Map to hold a reference to `y` to avoid this use-after-free. 