### PR TITLE
Fix eigency::Map default ctor when using VectorXd

### DIFF
--- a/eigency/eigency_cpp.h
+++ b/eigency/eigency_cpp.h
@@ -418,8 +418,15 @@ public:
     typedef MapBase<MatrixType> Base;
     typedef typename MatrixType::Scalar Scalar;
 
+    enum {
+        RowsAtCompileTime = Base::Base::RowsAtCompileTime,
+        ColsAtCompileTime = Base::Base::ColsAtCompileTime
+    };
+
     Map()
-        : Base(NULL, 0, 0),
+        : Base(NULL,
+               (RowsAtCompileTime == Eigen::Dynamic) ? 0 : RowsAtCompileTime,
+               (ColsAtCompileTime == Eigen::Dynamic) ? 0 : ColsAtCompileTime),
           object_(NULL) {
     }
     


### PR DESCRIPTION
Previously, the `eigency::Map` default constructor passed down hard-coded `rows == 0` and `cols == 0` into the Eigen::Map constructor.  However, when `RowsAtCompileTime` or `ColsAtCompileTime` are non-`Dynamic`, then `Eigen::Map` has a (debug-only) assertion in `variable_if_dynamic` that `rows` and `cols` exactly match their compile-time values.  When using eigency with Eigen assertions armed, an `eigency::Map<Eigen::VectorXd>` would always trip the runtime assertion.

This patch avoids that assertion by using passing the compile-time `eigency::Map` sizes into `Eigen::Map` constructor arguments when available.

Here's a sample backtrace of the relevant assertion failure:
```
in __GI___assert_fail (assertion=... "v == T(Value)",  file=... "external/eigen/Eigen/src/Core/util/XprHelper.h", line=110,  function=... <Eigen::internal::variable_if_dynamic<long, 1>::variable_if_dynamic(long)::__PRETTY_FUNCTION__> "Eigen::internal::variable_if_dynamic<T, Value>::variable_if_dynamic(T) [with T = long int; int Value = 1]") at assert.c:101
in Eigen::internal::variable_if_dynamic<long, 1>::variable_if_dynamic ( this=... v=0) at external/eigen/Eigen/src/Core/util/XprHelper.h:110
in Eigen::MapBase<Eigen::Map<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0> >, 0>::MapBase (this=... dataPtr=0x0, rows=0, cols=0) at external/eigen/Eigen/src/Core/MapBase.h:171
in Eigen::MapBase<Eigen::Map<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0> >, 1>::MapBase (this=... dataPtr=0x0, rows=0, cols=0) at external/eigen/Eigen/src/Core/MapBase.h:281
in Eigen::Map<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0> >::Map ( this=... dataPtr=0x0, rows=0, cols=0, stride=...) at external/eigen/Eigen/src/Core/Map.h:150
in eigency::MapBase<Eigen::Matrix<double, -1, 1, 0, -1, 1>, 0, Eigen::Stride<0, 0> >::MapBase (this=... data=0x0, rows=0, cols=0, stride=...) at external/gtborg_gtsam/cython/gtsam_eigency/eigency_cpp.h:308
in eigency::Map<Eigen::Matrix<double, -1, 1, 0, -1, 1> >::Map (this=... at external/gtborg_gtsam/cython/gtsam_eigency/eigency_cpp.h:398
```