### PR TITLE
[msvc] Fixed a MSVC compilation with eigency_cpp.h

### DIFF
--- a/eigency/eigency_cpp.h
+++ b/eigency/eigency_cpp.h
@@ -316,7 +316,7 @@ public:
 };
 
 
-template <template<class,int,int,int,int,int> class DenseBase,
+template <template<class,int,int,int,int,int> class EigencyDenseBase,
           typename Scalar,
           int _Rows, int _Cols,
           int _Options = Eigen::AutoAlign |
@@ -348,9 +348,9 @@ template <template<class,int,int,int,int,int> class DenseBase,
           int _StrideOuter=0, int _StrideInner=0,
           int _MaxRows = _Rows,
           int _MaxCols = _Cols>
-class FlattenedMap: public MapBase<DenseBase<Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>, _MapOptions, Eigen::Stride<_StrideOuter, _StrideInner> >  {
+class FlattenedMap: public MapBase<EigencyDenseBase<Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>, _MapOptions, Eigen::Stride<_StrideOuter, _StrideInner> >  {
 public:
-    typedef MapBase<DenseBase<Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>, _MapOptions, Eigen::Stride<_StrideOuter, _StrideInner> > Base;
+    typedef MapBase<EigencyDenseBase<Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>, _MapOptions, Eigen::Stride<_StrideOuter, _StrideInner> > Base;
 
     FlattenedMap()
         : Base(NULL, 0, 0),
@@ -399,8 +399,8 @@ public:
         return static_cast<Base&>(*this);
     }
 
-    operator DenseBase<Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>() const {
-        return DenseBase<Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>(static_cast<Base>(*this));
+    operator EigencyDenseBase<Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>() const {
+        return EigencyDenseBase<Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>(static_cast<Base>(*this));
     }
 
     virtual ~FlattenedMap() {
@@ -492,6 +492,3 @@ private:
 }
 
 #endif
-
-
-


### PR DESCRIPTION
The compiler is using DenseBase class defined by eigen, and not the one
declared in file eigency_cpp.h

Renaming class DenseBase with EigencyDenseBase fixes the problem

Below is MSVC2015 (14.0) error message (in French) where it says the number of
arguments is too high to use DenseBase, that is defined in
eigency/eigen_3.2.8/eigen/src/Core/DenseBase.h

    eigency_tests>python --version
    Python 3.6.4
    eigency_tests>python -c'import numpy;print(numpy.__version__)'
    1.14.0
    eigency_tests>python3 setup.py build
    running build
    running build_py
    running build_ext
    building 'eigency_tests.eigency_tests' extension
    C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\BIN\x86_amd64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD "-IC:\Program Files\Python36\lib\site-packages\eigency-1.75-py3.6-win-amd64.egg\eigency"
     -I. -Ieigency_tests "-IC:\Program Files\Python36\lib\site-packages\numpy\core\include" "-IC:\Program Files\Python36\lib\site-packages\eigency-1.75-py3.6-win-amd64.egg\eigency\eigen_3.2.8" "-IC:\Progr
    am Files\Python36\include" "-IC:\Program Files\Python36\include" "-IC:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\INCLUDE" "-IC:\Program Files (x86)\Windows Kits\10\include\10.0.10240.0\ucrt"
     "-IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.6.1\include\um" "-IC:\Program Files (x86)\Windows Kits\8.1\include\\shared" "-IC:\Program Files (x86)\Windows Kits\8.1\include\\um" "-IC:\Program Fil
    es (x86)\Windows Kits\8.1\include\\winrt" /EHsc /Tpeigency_tests/eigency_tests.cpp /Fobuild\temp.win-amd64-3.6\Release\eigency_tests/eigency_tests.obj
    eigency_tests.cpp
    c:\program files\python36\lib\site-packages\numpy\core\include\numpy\npy_1_7_deprecated_api.h(12) : Warning Msg: Using deprecated NumPy API, disable it by #defining NPY_NO_DEPRECATED_API NPY_1_7_API_V
    ERSION
    C:\Program Files\Python36\lib\site-packages\eigency-1.75-py3.6-win-amd64.egg\eigency\eigency_cpp.h(352): error C2977: 'Eigen::DenseBase' : nombre d'arguments modèle trop élevé
    c:\program files\python36\lib\site-packages\eigency-1.75-py3.6-win-amd64.egg\eigency\eigen_3.2.8\eigen\src/Core/DenseBase.h(43): note: voir la déclaration de 'Eigen::DenseBase'
    eigency_tests/eigency_tests.cpp(2396): note: voir la référence à l'instanciation de la classe modèle 'eigency::FlattenedMap<Eigen::Array,double,-1,1,0,0,0,0,-1,1>' en cours de compilation
    C:\Program Files\Python36\lib\site-packages\eigency-1.75-py3.6-win-amd64.egg\eigency\eigency_cpp.h(391): error C2977: 'Eigen::DenseBase' : nombre d'arguments modèle trop élevé