### PR TITLE
Ci travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: required
+dist: trusty
+language: python
+
+python:
+    - 2.7
+    - 3.4
+    - 3.5
+    - 3.6
+
+install:
+  - travis_retry pip install cython
+
+script:
+  - python --version
+  - python setup.py build
+  - python setup.py install
+  - cd tests
+  - python setup.py build
+  - python setup.py install
+  - python run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ script:
   - cd tests
   - python setup.py build
   - python setup.py install
-  - python run_tests.py
+  - cd ..
+  - python tests/run_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,7 @@ script:
   - cd tests
   - python setup.py build
   - python setup.py install
-  - cd ..
-  - python tests/run_tests.py
+  - mkdir test_run
+  - cp run_tests.py test_run/.
+  - cd test_run
+  - python run_tests.py


### PR DESCRIPTION
This PR adds CI with travis on linux with python 27, 34,35,36. 

It compiles the eigency, creates package and tests it.

Results can be seen here : https://travis-ci.org/Gjacquenot/eigency

To activate travis-ci, @wouterboomsma you need to create an account on https://travis-ci.org with GitHub credentials. Then, you can add a nice badge in the readme to show everything is fine.

Badge can look like this: 

[![Build Status](https://travis-ci.org/Gjacquenot/eigency.svg?branch=master)](https://travis-ci.org/Gjacquenot/eigency)

https://travis-ci.org/Gjacquenot/eigency.svg?branch=master
