### PR TITLE
Remove cython dependency (unless actually making the .cpp files)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,13 @@ __package_name__ = "eigency"
 __eigen_dir__ = eigency.__eigen_dir__
 __eigen_lib_dir__ = join(basename(__eigen_dir__), 'Eigen')
 
+# Not all users may have cython installed.  If they only want this as a means
+# to access the Eigen header files to compile their own C++ code, then they
+# may not have cython already installed.  Therefore, only require cython
+# for cases where the user will need to build the .cpp files from the .pyx
+# files (typically from a git clone) and not for other pip installations.
+# cf. discussion in PR #26.
+
 # Follow the pattern recommended here:
 # http://cython.readthedocs.io/en/latest/src/reference/compilation.html#distributing-cython-modules
 try:


### PR DESCRIPTION
Take 2 on removing cython requirement for pip users.  (Original try with PR #21 didn't work on all systems, including Travis.)

I found this recommendation from the [official cython page](http://cython.readthedocs.io/en/latest/src/reference/compilation.html#distributing-cython-modules), which is significantly less hackish than my previous attempt, and doesn't need cython as either a setup or install dependency anymore.

As I understand it, with this scenario, the .cpp files will be distributed by pip, so people who get it that way won't need cython to make them.  Just people who git clone the repo would need to have cython installed to make the .cpp files from scratch.  

This was already the case prior to this PR, since running setup.py without cython gave an ImportError, so there is no regression here.  It just lets pip installers not have cython and still be able to pip install eigency.  (I think.  Technically, that's as yet unproven.)