### PR TITLE
Include .cpp files in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,7 @@ include eigency/*.h
 include eigency/*.py
 include eigency/*.pyd
 include eigency/*.pyx
-exclude eigency/*.cpp
+include eigency/*.cpp
 
 # tests
 recursive-include tests *.cpp *.h *.py *.pyx


### PR DESCRIPTION
Unfortunately, the pip distribution for version 1.77 doesn't seem to have been made correctly to allow for non-cython installations.  In particular, the .cpp files weren't included in the tarball.  

After pip downloads and unpacks the tarball, here is the listing of the eigen directory:
```
~/tmp/eigency-1.77 $ ls eigency
__init__.py        conversions.pyx    core.pxd           eigen_3.2.8/
conversions.pxd    conversions_api.h  core.pyx           eigency_cpp.h
```
Note that `conversion.cpp` and `core.cpp` are missing.

I'm pretty sure the fix (in this PR) is simply to change the MANIFEST.in file to have
```
include eigency/*.cpp
```
rather than `exclude`.  My fault for not noticing this when I submitted this PR #26

Also, it's worth pointing out a way to double check that these files are included in the tarball.
Before doing the upload, you can do
```
python setup.py sdist
grep .cpp eigency.egg-info/SOURCES.txt 
```
This will show you the .cpp files that are slated to be included in the tarball.  Currently only a few in the tests directory are included.  Not any from the eigency directory.  But with this change to the MANIFEST, they get included in the listing.

Sorry for bothering you about this again...  :(