### PR TITLE
make eigency_cpp.h self-contained

### DIFF
--- a/eigency/eigency_cpp.h
+++ b/eigency/eigency_cpp.h
@@ -7,6 +7,8 @@
 typedef ::std::complex< double > __pyx_t_double_complex;
 typedef ::std::complex< float > __pyx_t_float_complex;
 
+#include <numpy/ndarraytypes.h>
+
 #include "conversions_api.h"
 
 #ifndef EIGENCY_CPP


### PR DESCRIPTION
The cythonized `conversions_api.h` is sadly not self-contained (it includes only Python.h) and has following declarations

```C
static PyArrayObject *(*__pyx_api_f_11conversions_ndarray_copy_complex_float_F)(__pyx_t_float_complex const *, long, long, long, long) = 0;
```

while `__pyx_t_float_complex` is taken care of in egency_cpp.h a defintion of `PyArrayObject` is missing.