### PR TITLE
Add pyproject.toml for compliance with PEP 517 and 518

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# IDEs
+.idea/
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "setuptools>=38",
     "setuptools_scm",
+    "wheel",
     "numpy",
     "Cython"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "setuptools>=38",
     "setuptools_scm",
-    "wheel",
     "numpy",
     "Cython"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "setuptools>=38",
+    "setuptools_scm",
+    "numpy",
+    "Cython"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,14 @@
 import os
+import sys
 from os.path import basename, join
 from setuptools import setup, find_packages
 from setuptools.extension import Extension
 
-import eigency
 import numpy as np
+
+sys.path.append(".")
+
+import eigency
 
 __package_name__ = "eigency"
 __eigen_dir__ = eigency.__eigen_dir__

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ dist = setup(
     author_email = "wb@di.ku.dk",
     url = "https://github.com/wouterboomsma/eigency",
     use_scm_version = True,
-    setup_requires = ['setuptools>=38','setuptools_scm'],
     ext_modules = extensions,
     packages = find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Closes #34 

@wouterboomsma Please consider merging this asap and release an updated version to pypi. The latest version fails to install normally through pip unless `numpy` is pre-installed at the system-level or in the activated virtual environment.

Also, PR #27 should be merged as well so that `Cython` can be removed from the `pyproject.toml` file in my PR.