### PR TITLE
Make sdist tar file consistent across build environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[sdist]
+owner = root
+group = root


### PR DESCRIPTION
Add [sdist] entry to setup.cfg to produce consistent sdist tar file.
Add "venv" to .gitignore.