### PR TITLE
Use oldest-supported-numpy for building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "setuptools_scm",
-    "numpy",
+    "oldest-supported-numpy",
     "Cython"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Noticed a problem that Eigency currently uses latest NumPy for building, however, it should use oldest supported NumPy version. Noticed it while debugging segmentation fault in a project using Eigency, it turned out that Eigency is built against latest NumPy from pip (right now 1.23.3), however, if system/venv has older NumPy, it can lead to crash due to ABI incompatibility (system/venv Numpy version must be always the same or greater than NumPy used for building).

More detailed and clearer explanation is at NumPy webpage:
https://numpy.org/doc/stable/user/depending_on_numpy.html#adding-a-dependency-on-numpy

This pull request changes the behavior to use oldest-supported-numpy as suggested by NumPy documentation.