### PR TITLE
decrement refcount before destruction

### DIFF
--- a/eigency/eigency_cpp.h
+++ b/eigency/eigency_cpp.h
@@ -257,6 +257,11 @@ public:
         Py_XINCREF(object_);
     }
     FlattenedMap &operator=(const FlattenedMap &other) {
+        if (this == &other){
+            return *this;
+        }
+
+        Py_XDECREF(object_);
         if (other.object_) {
             new (this) FlattenedMap(other.object_);
         } else {
@@ -338,6 +343,11 @@ public:
     }
 
     Map &operator=(const Map &other) {
+        if (this == &other){
+            return *this;
+        }
+
+        Py_XDECREF(object_);
         if (other.object_) {
             new (this) Map(other.object_);
         } else {


### PR DESCRIPTION
Hello, use eigency intensively and I encounter a memory leak. The call to "new" uses the allocated memory of "this" but does not call the destructor (in this case, we need the decrement the counter of object_) before overwriting the memory . 

Thanks 