### PR TITLE
Fix Cython v3 compatibility with tests

### DIFF
--- a/tests/eigency_tests/eigency_tests.pyx
+++ b/tests/eigency_tests/eigency_tests.pyx
@@ -40,9 +40,9 @@ cdef extern from "eigency_tests/eigency_tests_cpp.h":
 
      cdef Map[ArrayXXd] &_function_filter1 "function_filter1" (Map[ArrayXXd] &)
 
-     cdef FlattenedMapWithOrder[Array, double, Dynamic, Dynamic, RowMajor] &_function_filter2 "function_filter2" (FlattenedMapWithOrder[Array, double, Dynamic, Dynamic, RowMajor] &)
+     cdef PlainObjectBase _function_filter2 "function_filter2" (FlattenedMapWithOrder[Array, double, Dynamic, Dynamic, RowMajor] &)
 
-     cdef FlattenedMapWithStride[Array, double, Dynamic, Dynamic, ColMajor, Unaligned, _1, Dynamic] &_function_filter3 "function_filter3" (FlattenedMapWithStride[Array, double, Dynamic, Dynamic, ColMajor, Unaligned, _1, Dynamic] &)
+     cdef PlainObjectBase _function_filter3 "function_filter3" (FlattenedMapWithStride[Array, double, Dynamic, Dynamic, ColMajor, Unaligned, _1, Dynamic] &)
 
      cdef PlainObjectBase _function_type_double "function_type_double" (Map[ArrayXXd] &)
      cdef PlainObjectBase _function_type_float "function_type_float" (Map[ArrayXXf] &)

--- a/tests/eigency_tests/eigency_tests.pyx
+++ b/tests/eigency_tests/eigency_tests.pyx
@@ -40,9 +40,9 @@ cdef extern from "eigency_tests/eigency_tests_cpp.h":
 
      cdef Map[ArrayXXd] &_function_filter1 "function_filter1" (Map[ArrayXXd] &)
 
-     cdef PlainObjectBase _function_filter2 "function_filter2" (FlattenedMapWithOrder[Array, double, Dynamic, Dynamic, RowMajor])
+     cdef FlattenedMapWithOrder[Array, double, Dynamic, Dynamic, RowMajor] &_function_filter2 "function_filter2" (FlattenedMapWithOrder[Array, double, Dynamic, Dynamic, RowMajor] &)
 
-     cdef PlainObjectBase _function_filter3 "function_filter3" (FlattenedMapWithStride[Array, double, Dynamic, Dynamic, ColMajor, Unaligned, _1, Dynamic])
+     cdef FlattenedMapWithStride[Array, double, Dynamic, Dynamic, ColMajor, Unaligned, _1, Dynamic] &_function_filter3 "function_filter3" (FlattenedMapWithStride[Array, double, Dynamic, Dynamic, ColMajor, Unaligned, _1, Dynamic] &)
 
      cdef PlainObjectBase _function_type_double "function_type_double" (Map[ArrayXXd] &)
      cdef PlainObjectBase _function_type_float "function_type_float" (Map[ArrayXXf] &)


### PR DESCRIPTION
Eigency tests are failing to build.

The compile errors point to `filter2` and `filter3` function tests. Tests build successfully with Cython 0.29.36 but fail with Cython 3.0.0+. Unknown cause but error messages point to `__PYX_STD_MOVE_IF_SUPPORTED` macro.

Underlying C++ error message:
```
error: cannot bind non-const lvalue reference of type ‘RowMajorArrayMap&’ {aka ‘Eigen::Map<Eigen::Array<double, -1, -1, 1> >&’} to an rvalue of type ‘Eigen::Map<Eigen::Array<double, -1, -1, 1> >’
```