### PR TITLE
fix constructor for debug compilation

### DIFF
--- a/eigency/eigency_cpp.h
+++ b/eigency/eigency_cpp.h
@@ -233,7 +233,9 @@ public:
     typedef MapBase<EigencyDenseBase<Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>, _MapOptions, Eigen::Stride<_StrideOuter, _StrideInner> > Base;
 
     FlattenedMap()
-        : Base(NULL, 0, 0),
+        : Base(NULL,
+               _Rows == Eigen::Dynamic ? 0 : _Rows,
+               _Cols == Eigen::Dynamic ? 0 : _Cols),
           object_(NULL) {}
 
     FlattenedMap(Scalar *data, long rows, long cols, long outer_stride=0, long inner_stride=0)


### PR DESCRIPTION
Cython in debug configuration generetate the following code (compiled with -UNDEBUG):

    ....
    eigency::FlattenedMap<Eigen::Matrix,Muscat::CMuscatIndex,Eigen::Dynamic,1>  __pyx_t_2;
    ....
    try {
       __pyx_t_2 = eigency::FlattenedMap<Eigen::Matrix,Muscat::CMuscatIndex,Eigen::Dynamic,1> (((PyArrayObject *)__pyx_v_ids));
    } catch(...) {
    ....

Need a correction of the default constructor to adapt to the correct size ( (Eigen::Dynamic,1)  in this case)  .

Felipe 